### PR TITLE
WI #23 [BUG]: Helm chart reference is incorrect in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,10 @@ To run a method from within a test
 ### Deployment
 
 The component can be deployed as a Kubernetes pod by installing Notification Center charts.
-Link: [Charts](../../../ecsp-helm-charts/tree/main/notification-center)
+
+Links: 
+[Notification-Api Charts](../../../ecsp-helm-charts/tree/main/notification-api)
+[Notification-Sp Charts](../../../ecsp-helm-charts/tree/main/notification-sp)
 
 ## Architecture
 


### PR DESCRIPTION
Fixed the helm chart reference in readme

Please refer to our [contributing docs](./CONTRIBUTING.md) for any questions on submitting a pull request.
Issues are required for both bug fixes and features.

Resolves #23  
<!-- Link to related issue(s) -->

----
### Describe behaviour before the change
<!-- Please describe the current behavior that you are modifying. -->

* Link to the notification charts from readme file was not working & giving "404 not found".

### Describe behaviour after the change
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Link to the notification charts from readme file is woking & redirecting to helm charts notification-centre (api & sp).

### Pull request checklist
- [x] I have read the [CONTRIBUTING.md](./CONTRIBUTING.md)
- [x] My code follows the code style of this project
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] All new and existing tests passed.
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

- [ ] Yes
- [x] No

----

